### PR TITLE
Suggestion: Pass initial value to read function for argument

### DIFF
--- a/mag-menu.el
+++ b/mag-menu.el
@@ -203,7 +203,8 @@ put it in mag-menu-key-maps for fast lookup."
       (mag-menu-kill-buffer))))
 
 (defun mag-menu-add-argument (group arg-name input-func)
-  (let ((input (funcall input-func (concat arg-name ": "))))
+  (let* ((old (gethash arg-name mag-menu-current-args))
+         (input (funcall input-func (concat arg-name ": ") old)))
     (if (= (length input) 0)
         (remhash arg-name mag-menu-current-args)
         (puthash arg-name input mag-menu-current-args))


### PR DESCRIPTION
This pull request breaks backward compatibility.  It is just for suggesting a change.

If it is merged, ack-menu should provide read function like this:

``` lisp
(defun ack-menu-read-match (prompt &optional initial-contents)
  (read-from-minibuffer prompt initial-contents nil nil 'ack-menu-match-history))
```

Then, you can edit old search pattern.

I can think of other ways to do this:
1. Use keyword argument for callback and require function to ignore any unused keyword arguments, so that it will not break compatibility when you add another arguments in the future.
2. Use dynamical binding.

``` lisp
(defun ack-menu-read-match (prompt)
  (read-from-minibuffer prompt mag-menu-argument-initial-contents
                        nil nil 'ack-menu-match-history))
```

which is bound in `mag-menu-add-argument` like this

``` lisp
(defun mag-menu-add-argument (group arg-name input-func)
  (let* ((mag-menu-argument-initial-contents
          (gethash arg-name mag-menu-current-args))
         (input (funcall input-func (concat arg-name ": "))))
    (if (= (length input) 0)
        (remhash arg-name mag-menu-current-args)
        (puthash arg-name input mag-menu-current-args))
   (mag-menu-redraw group)))
```

This will not break compatibility.
